### PR TITLE
Whitelist fix

### DIFF
--- a/cfg/whitelists/owl.txt
+++ b/cfg/whitelists/owl.txt
@@ -1,8 +1,8 @@
-// Whitelist generated at Tue, 06 May 2014 08:28:36 +0200
-// Custom Whitelist ID: 908
+// Whitelist generated at Tue, 06 May 2014 14:00:55 +0200
+// Whitelist: ozfortress 6v6 (OWL 11) (ID: 908)
 
 // Share or view this whitelist:
-//	http://whitelist.tf/908
+//	http://whitelist.tf/ozfortress_6v6
 
 // New items added to the game are: NOT allowed
 // Hats are: allowed


### PR DESCRIPTION
Uses the whitelist.tf version of the OWL 11 whitelist found here http://whitelist.tf/ozfortress_6v6

Fixes blutsauger
Fixes OWL medals
Includes all new hats and miscs. 
