### PR TITLE
tv delay protect to 0

### DIFF
--- a/cfg/autoexec.cfg
+++ b/cfg/autoexec.cfg
@@ -61,7 +61,7 @@ tv_allow_static_shots 0
 tv_chattimelimit 2
 tv_delay 90
 tv_delaymapchange 1
-tv_delaymapchange_protect 1
+tv_delaymapchange_protect 0
 tv_dispatchmode 1
 tv_maxclients 5
 tv_maxrate 0


### PR DESCRIPTION
no need for 1 unless casted event