### PR TITLE
Updated badlands map alias

### DIFF
--- a/cfg/autoexec.cfg
+++ b/cfg/autoexec.cfg
@@ -85,8 +85,8 @@ tf_arena_first_blood 0
 tf_flag_caps_per_round 0
 
 // Map Aliases
-alias badlands "changelevel cp_prolands_b2b"
-alias prolands "changelevel cp_prolands_b2b"
+alias badlands "changelevel cp_prolands_b3a"
+alias prolands "changelevel cp_prolands_b3a"
 alias bagel "changelevel koth_bagel_rc2a"
 alias process "changelevel cp_process_final"
 alias sunshine "changelevel cp_sunshine"


### PR DESCRIPTION
Now using cp_prolands_b3a to encourage scrimming on the new version.